### PR TITLE
add Gogo Descriptor and additional checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This plugin provides some cool utilities for adding module-infos to existing dep
 This should create a jlink image under `atomos/atomos.tests/service.image/target/atomos`.  Executing the following command
 against the jlink image should produce a gogo shell prompt:
 
-`atomos/bin/atomos`
+`./bin/atomos`
 
 You should see the following output:
 
@@ -44,12 +44,25 @@ they cannot be automatic modules.
 The `atomos.tests/service.image` example uses the latest `1.0.0.Beta2` version of the `moditect-maven-plugin` to
 add `module-info.class` as necessary to the bundles used in the image.
 
-You can also load additional modules into atomos by using the `atomos.modules` option when launching `atomos`.
+You can also load additional modules into atomos at:
+
+ - System start
+by using the `atomos.modules` option when launching `atomos`.
 For example:
 
 ```
 atomos/bin/atomos atomos.modules=/path/to/more/modules
 ```
+
+ - Runtime
+by using the gogo command `atomos:install`
+For example:
+
+```
+atomos:install MyLayerName OSGI /path/to/more/modules
+```
+
+
 When doing that the additional modules will be loaded into a child layer where the Atomos OSGi Framework
 will control the class loaders.  This will produce a class loader per module bundle installed.  This has
 advantages because it allows the module class loader for the bundle to implement the

--- a/atomos.framework/pom.xml
+++ b/atomos.framework/pom.xml
@@ -15,17 +15,16 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-
-    <repositories>
-        <repository>
-            <id>atomos-temp-m2repo</id>
-            <url>https://github.com/tjwatson/atomos-temp-m2repo/raw/master/repository</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>atomos-temp-m2repo</id>
+			<url>https://github.com/tjwatson/atomos-temp-m2repo/raw/master/repository</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -40,6 +39,11 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>osgi.annotation</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.gogo.runtime</artifactId>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/atomos.framework/src/main/java/module-info.java
+++ b/atomos.framework/src/main/java/module-info.java
@@ -17,6 +17,7 @@ open module atomos.framework {
 	requires transitive org.eclipse.osgi;
 	requires static osgi.annotation;
 	requires static jdk.unsupported;
+	requires static org.apache.felix.gogo.runtime;
 	uses ConnectFrameworkFactory;
 	provides FrameworkUtilHelper with AtomosFrameworkUtilHelper;
 }

--- a/atomos.framework/src/main/java/org/atomos/framework/base/AtomosCommands.java
+++ b/atomos.framework/src/main/java/org/atomos/framework/base/AtomosCommands.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Stefan Bischof  - gogo descriptors and checks
  *******************************************************************************/
 package org.atomos.framework.base;
 
@@ -16,8 +17,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.felix.service.command.Descriptor;
 import org.atomos.framework.AtomosBundleInfo;
 import org.atomos.framework.AtomosLayer;
 import org.atomos.framework.AtomosRuntime.LoaderType;
@@ -28,7 +33,7 @@ import org.osgi.framework.ServiceRegistration;
 
 public class AtomosCommands {
 
-	public String[] functions = new String[] {"list", "install", "uninstall"};
+	public static String[] functions = new String[] { "list", "install", "uninstall" };
 	private final AtomosRuntimeBase runtime;
 
 	public AtomosCommands(AtomosRuntimeBase runtime) {
@@ -36,29 +41,30 @@ public class AtomosCommands {
 	}
 
 	public ServiceRegistration<AtomosCommands> register(BundleContext context) {
-		Hashtable<String, Object> props = new Hashtable<>();
+		final Hashtable<String, Object> props = new Hashtable<>();
 		props.put("osgi.command.function", functions);
 		props.put("osgi.command.scope", "atomos");
 		return context.registerService(AtomosCommands.class, this, props);
 	}
 
+	@Descriptor("List all layers")
 	public void list() {
-		AtomosLayer bl = runtime.getBootLayer();
+		final AtomosLayer bl = runtime.getBootLayer();
 		layers(bl.getParents().stream().findFirst().orElseGet(() -> bl), new HashSet<>());
 	}
 
 	private void layers(AtomosLayer layer, Set<AtomosLayer> visited) {
 		if (visited.add(layer)) {
 			System.out.println(layer.toString());
-			Set<AtomosBundleInfo> bundles = layer.getAtomosBundles();
+			final Set<AtomosBundleInfo> bundles = layer.getAtomosBundles();
 			if (!bundles.isEmpty()) {
 				System.out.println(" BUNDLES:");
-				for (AtomosBundleInfo bundle : bundles) {
-					Bundle b = runtime.getBundle(bundle);
+				for (final AtomosBundleInfo bundle : bundles) {
+					final Bundle b = runtime.getBundle(bundle);
 					System.out.println("  " + bundle.getSymbolicName() + getState(b));
 				}
 			}
-			for (AtomosLayer child : layer.getChildren()) {
+			for (final AtomosLayer child : layer.getChildren()) {
 				layers(child, visited);
 			}
 		}
@@ -86,29 +92,57 @@ public class AtomosCommands {
 		}
 	}
 
-	public void install(String name, String loaderType, File moduleDir) throws BundleException {
+	@Descriptor("Install a new layer")
+	public void install(@Descriptor("Name of the layer") String name,
+			@Descriptor("LoaderType of the layer [OSGI, SINGLE, MANY]") String loaderType,
+			@Descriptor("Directory where the AtomosBundles are stored") File moduleDir)
+					throws BundleException {
+
 		if (!moduleDir.isDirectory()) {
 			System.out.println("The specified path is not a directory: " + moduleDir.getAbsolutePath());
+			return;
 		}
 
-		AtomosLayer layer = runtime.addLayer(Collections.singletonList(runtime.getBootLayer()), name, LoaderType.valueOf(loaderType), moduleDir.toPath());
-		
-		List<Bundle> bundles = new ArrayList<>();
-		for (AtomosBundleInfo atomosBundle : layer.getAtomosBundles()) {
+		final Optional<LoaderType> oLoaderType = Stream.of(LoaderType.values())
+				.filter(e -> e.name().equalsIgnoreCase(loaderType))
+				.findAny();
+
+		if (!oLoaderType.isPresent()) {
+			final String v = Stream.of(LoaderType.values())
+					.map(LoaderType::name)
+					.collect(Collectors.joining(", "));
+			System.out.printf("The specified loaderType is not valid. Use one of %s", v);
+			return;
+		}
+
+		final AtomosLayer layer = runtime.addLayer(Collections.singletonList(runtime.getBootLayer()),
+				name, oLoaderType.get(), moduleDir.toPath());
+
+		final List<Bundle> bundles = new ArrayList<>();
+		for (final AtomosBundleInfo atomosBundle : layer.getAtomosBundles()) {
 			bundles.add(atomosBundle.install(null));
 		}
-		for (Bundle b : bundles) {
+		for (final Bundle b : bundles) {
 			b.start();
 		}
 		layers(layer, new HashSet<>());
 	}
 
-	public void uninstall(long id) throws BundleException {
-		AtomosLayer layer = runtime.getById(id);
+
+	@Descriptor("Uninstall the layer with the given id")
+	public void uninstall(@Descriptor("Id of the layer") long id) throws BundleException {
+
+		final AtomosLayer layer = runtime.getById(id);
 		if (layer == null) {
 			System.out.println("No Atomos Layer with ID: " + id);
 		} else {
-			layer.uninstall();
+			try {
+				layer.uninstall();
+				System.out.printf("Sucessfully uninstalled Atomos Layer \"%s\" with ID: %s",
+						layer.getName(), id);
+			} catch (final Exception e) {
+				throw e;
+			}
 		}
 	}
 }

--- a/atomos.tests/classpath.service.test/src/test/java/org/atomos/classpath/service/test/ClasspathLaunchTest.java
+++ b/atomos.tests/classpath.service.test/src/test/java/org/atomos/classpath/service/test/ClasspathLaunchTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +32,7 @@ import org.atomos.framework.AtomosBundleInfo;
 import org.atomos.framework.AtomosLayer;
 import org.atomos.framework.AtomosRuntime;
 import org.atomos.framework.AtomosRuntime.LoaderType;
+import org.atomos.framework.base.AtomosCommands;
 import org.atomos.service.contract.Echo;
 import org.junit.After;
 import org.junit.Before;
@@ -68,6 +70,26 @@ public class ClasspathLaunchTest {
 	      .sorted(Comparator.reverseOrder())
 	      .map(Path::toFile)
 	      .forEach(File::delete);
+	}
+
+	@Test
+	public void testClassPathGogo() throws BundleException, InvalidSyntaxException {
+
+		ClasspathLaunch.main(
+				new String[] { Constants.FRAMEWORK_STORAGE + '=' + storage.toFile().getAbsolutePath() });
+		testFramework = ClasspathLaunch.getFramework();
+		BundleContext bc = testFramework.getBundleContext();
+
+		String filter = "(osgi.command.scope=atomos)";
+
+		Collection<ServiceReference<AtomosCommands>> serviceReferences = bc
+				.getServiceReferences(AtomosCommands.class, filter);
+
+		assertEquals(1, serviceReferences.size());
+		AtomosCommands ac = bc.getService(serviceReferences.iterator().next());
+		assertNotNull("AtomosCommands required", ac);
+		ac.list();
+
 	}
 
 	@Test


### PR DESCRIPTION
gogo commands like `help atomos:install` now could show more desciptive information

```
g! help atomos:install
install - Install a new layer
   scope: atomos
   parameters:
      String   Name of the layer
      String   LoaderType of the layer [OSGI, SINGLE, MANY]
      File   Directory where the AtomosBundles are stored
```

```
g! help atomos:uninstall
uninstall - Uninstall the layer with the given id
   scope: atomos
   parameters:
      long   Id of the layer
```

```
g! help atomos:list
list - List all layers
   scope: atomos

```


Signed-off-by: Stefan Bischof <stbischof@bipolis.org>